### PR TITLE
[script][common-crafting] Check both anvil/crucible

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -34,7 +34,7 @@ module DRCC
   end
 
   def find_empty_crucible(hometown)
-    return if DRC.bput('tap crucible', 'I could not', /You tap.*crucible/) =~ /You tap.*crucible/ && (DRRoom.pcs - DRRoom.group_members).empty? && empty_crucible?
+    return if DRC.bput('tap crucible', 'I could not', /You tap.*crucible/) =~ /You tap.*crucible/ && (DRRoom.pcs - DRRoom.group_members).empty? && empty_crucible? && clean_anvil?
     crucibles = get_data('crafting')['blacksmithing'][hometown]['crucibles']
     idle_room = get_data('crafting')['blacksmithing'][hometown]['idle-room']
     DRCT.find_sorted_empty_room(crucibles, idle_room, proc { (DRRoom.pcs - DRRoom.group_members).empty? && empty_crucible? })
@@ -79,7 +79,7 @@ module DRCC
   end
 
   def find_anvil(hometown)
-    return if DRC.bput('tap anvil', 'I could not', /You tap.*anvil/) =~ /You tap.*anvil/ && (DRRoom.pcs - DRRoom.group_members).empty? && clean_anvil?
+    return if DRC.bput('tap anvil', 'I could not', /You tap.*anvil/) =~ /You tap.*anvil/ && (DRRoom.pcs - DRRoom.group_members).empty? && empty_crucible? && clean_anvil?
     anvils = get_data('crafting')['blacksmithing'][hometown]['anvils']
     idle_room = get_data('crafting')['blacksmithing'][hometown]['idle-room']
     DRCT.find_sorted_empty_room(anvils, idle_room, proc { (DRRoom.pcs - DRRoom.group_members).empty? && clean_anvil? })


### PR DESCRIPTION
Checks both clear anvil and clera crucible even if we're in a room with one or the other already, to prevent hangs with items in crucible or on anvil and fuel shoveling.